### PR TITLE
Fixes for HTTP 1.0 and 2.0

### DIFF
--- a/specs/http-client2/index.html
+++ b/specs/http-client2/index.html
@@ -129,6 +129,14 @@
           these methods do not appear to be widely used, they are still supported via the
           <a>http:send</a> function.
       </section>
+      <section id="http2-support">
+        <h3>HTTP/2 Support</h3>
+        <p>We acknowledge that HTTP/2 support is currently in its infancy. We have attempted to
+          design for a future version of this specification to extend control for HTTP/2 via.
+          extension points such as <code>$options</code> and further arity functions. We await
+          feedback from the users of the HTTP Client 2.0 spec, with regards to revisions for further
+          support of HTTP/2 features.</p>
+      </section>
     </section>
 
     <section id='functions'>
@@ -289,7 +297,8 @@ http:send($uri as xs:string, $method as xs:string, $body as item()?, $options as
         <dl>
           <dt><code>http-version</code> (<code>xs:string</code>)</dt>
           <dd>The HTTP Version to use for the request. Default: 1.1.
-            Supported versions are <code>1.0</code> and <code>1.1</code>.
+            Supported versions are <code>1.0</code>, <code>1.1</code>,
+            and <code>2.0</code>.
           </dd>
 
           <dt><code>headers</code> (<code>map(xs:string, xs:string)</code>)</dt>

--- a/specs/http-client2/index.html
+++ b/specs/http-client2/index.html
@@ -117,6 +117,20 @@
       </section>
     </section>
 
+    <section id='supported-http-versions'>
+      <h2>Supported HTTP versions</h2>
+      <p>Implementations of this module are expected to support HTTP 1.0 [[!rfc1945]],
+        1.1 [[!rfc2616]], and 2.0 [[!rfc7540]]. Unless otherwise explicitly stated in this
+        specification, client behaviour is expected to conform to the appropriate HTTP RFC.</p>
+      <section id="http1-support">
+        <h3>HTTP 1.0 Support</h3>
+        <p>This module supports all features of HTTP 1.0. Although we do not provide explicit
+          functions for the <code>LINK</code> and <code>UNLINK</code> HTTP methods, as in practice
+          these methods do not appear to be widely used, they are still supported via the
+          <a>http:send</a> function.
+      </section>
+    </section>
+
     <section id='functions'>
       <h2>Functions</h2>
       <p>
@@ -180,10 +194,6 @@ http:put($uri as xs:string, $body as item()?, $options as map(xs:string, item())
           Sends a PUT request with an optional <code>$body</code> to the supplied <code>$uri</code>
           and returns the response as a map. Additional <code>$options</code> can be supplied.
         </p>
-        <p>
-          HTTP PUT is only supported in HTTP 1.1. If <code>"http-version": "1.0"</code> is set in
-          the <code>$options</code> then <code>http:version</code> is raised.
-	</p>
       </section>
 
       <section>
@@ -197,10 +207,6 @@ http:delete($uri as xs:string, $options as map(xs:string, item())) as map(xs:str
         <p>
           Sends a DELETE request to the supplied <code>$uri</code> and returns the response as a
           map. Additional <code>$options</code> can be supplied.
-        </p>
-        <p>
-          HTTP DELETE is only supported in HTTP 1.1. If <code>"http-version": "1.0"</code> is set in
-          the <code>$options</code> then <code>http:version</code> is raised.
         </p>
       </section>
 
@@ -230,10 +236,6 @@ http:options($uri as xs:string, $options as map(xs:string, item())) as map(xs:st
           Sends an OPTIONS request to the supplied <code>$uri</code> and returns the response as a
           map. Additional <code>$options</code> can be supplied.
         </p>
-        <p>
-          HTTP OPTIONS is only supported in HTTP 1.1. If <code>"http-version": "1.0"</code> is set in
-          the <code>$options</code> then <code>http:version</code> is raised.
-        </p>
       </section>
 
       <section>
@@ -248,14 +250,10 @@ http:trace($uri as xs:string, $body as item()?, $options as map(xs:string, item(
           Sends a TRACE request with an optional <code>$body</code> to the supplied <code>$uri</code>
           and returns the response as a map. Additional <code>$options</code> can be supplied.
         </p>
-        <p>
-          HTTP TRACE is only supported in HTTP 1.1. If <code>"http-version": "1.0"</code> is set in
-          the <code>$options</code> then <code>http:version</code> is raised.
-        </p>
       </section>
 
       <section>
-        <h3>http:send</h3>
+        <h3><dfn>http:send</dfn></h3>
         <div class="exampleInner">
           <pre>
 http:send($uri as xs:string, $method as xs:string) as map(xs:string, item())
@@ -269,12 +267,6 @@ http:send($uri as xs:string, $method as xs:string, $body as item()?, $options as
           Additional <code>$options</code> can be supplied. The <code>$method</code> should be
           specified accoding to the appropriate specification, for HTTP this means in upper-case
           characters.
-        </p>
-        <p>
-          NOTE: HTTP 1.0 only supports the HTTP methods <code>GET</code>, <code>HEAD</code>, and
-          <code>PUT</code>. If <code>"http-version": "1.0"</code> is specified in
-          <code>$options</code> and an unsupported method is used, then the error
-          <code>http:version</code> is raised.
         </p>
       </section>
     </section>
@@ -317,7 +309,8 @@ http:send($uri as xs:string, $method as xs:string, $body as item()?, $options as
             for HTTP 1.0.
             NOTE: Setting the transfer-encoding option will override any transfer-encoding
             HTTP header.
-            NOTE: <code>chunked</code> is not supported on HTTP 1.0.
+            NOTE: <code>chunked</code> is not supported on HTTP 1.0, such use will raise the
+            <a>http:version</a> error.
           </dt>
 
           <dt><code>follow-redirect</code> (<code>xs:boolean</code>)</dt>
@@ -658,7 +651,7 @@ http:send($uri as xs:string, $method as xs:string, $body as item()?, $options as
       <dl>
         <dt><code>http:body</code></dt>
         <dd>A request body argument has an invalid type.</dd>
-        <dt><code>http:version</code></dt>
+        <dt><dfn>http:version</dfn></dt>
         <dd>A feature is not supported by the specified HTTP version.</dd>
         <dt><code>http:options</code></dt>
         <dd>The value of an option is invalid, or has an invalid type.</dd>

--- a/specs/http-client2/index.html
+++ b/specs/http-client2/index.html
@@ -41,7 +41,7 @@
               { name: "Christian Grün", url: "http://christian-gruen.de/",
                 company: "BaseX GmbH", companyURL: "http://basex.org/" },
               { name: "Adam Retter", url: "http://adamretter.org.uk/",
-                company: "Evolved Binary", companyURL: "http://adamretter.org.uk/" }
+                company: "Evolved Binary", companyURL: "http://evolvedbinary.com/" }
           ],
 
           // authors, add as many as you like.


### PR DESCRIPTION
1. Reduces constraints for HTTP 1.0, as the spec actually allows you to do some things with http methods which might not be supported, which is fine as the server must then return `501 (not implemented)` if it does not support it.

2. Adds basic support for HTTP 2.0.