### PR TITLE
Allow certificate based client authentication

### DIFF
--- a/specs/http-client2/index.html
+++ b/specs/http-client2/index.html
@@ -328,6 +328,28 @@ http:send($uri as xs:string, $method as xs:string, $body as item()?, $options as
             the fractional digits of the xs:decimal e.g. 0.200 is 200 milliseconds.
           </dd>
 
+          <dt><code>certificates</code> (<code>map(xs:string, item()+)+</code>)</dt>
+          <dd>Options for authenticating the client with the server using certificate(s). The type
+            and use of this option is implementation defined. Java implementations SHOULD use the
+            following definition:
+            <pre class="example" title="Certificates with a HTTP Client 2.0 Java Implementation">
+"certificates": (
+  map {
+    "trust": map {
+      "keystore": "/x/y/my-trust-store.jks",
+      "keystore-password": "trust-store-password",
+      "alias": "trust-certificate"
+    },
+    "client": map {
+      "keystore": "/x/y/my-client-store.jks",
+      "keystore-password": "client-store-password",
+      "alias": "my-certificate",
+      "password": "my-certificate-password"
+    }
+  }
+)
+            </pre>. In the above example the <code>alias</code> options are OPTIONAL.</dd>
+
           <dt><code>username</code> (<code>xs:string</code>)</dt>
           <dd>Authentication: username.</dd>
 


### PR DESCRIPTION
Closes https://github.com/expath/expath-cg/issues/76

I have given us quite a lot of *wiggle room* on this one, by making the actual details *implementation defined* (which I normally avoid).

However I have also restricted it a little by saying Java implementations *SHOULD* do it the same way. There pretty much seems to be only one way to do it in Java anyway, i.e. via *key stores*, both the JDK HTTP classes and the Apache HttpClient classes implement it.

It seems likely to me that only the Java XQuery/XSLT processors will implement this anyway (e.g. Saxon, BaseX, and eXist-db). The *implementation defined* though, allows for any other language implementation or a different Java implementation too.