### PR TITLE
Improve English language, and internal and external linking

### DIFF
--- a/specs/http-client/index.html
+++ b/specs/http-client/index.html
@@ -68,7 +68,7 @@
 	      value: 'GitHub expath/expath-cg',
 	      href: 'https://github.com/expath/expath-cg/'
 	    }, {
-	      value: 'File a bug',
+	      value: 'Report an issue',
 	      href: 'https://github.com/expath/expath-cg/issues/'
 	    }]
 	  }],
@@ -174,10 +174,15 @@
 
     <section id="abstract">
       <p>
-        This proposal provides an HTTP client interface for XPath 2.0.  It
-        defines one extension function to perform HTTP requests, and has been
-        designed to be compatible with XQuery 1.0 and XSLT 2.0, as well as any
-        other XPath 2.0 usage.
+        This specification defines an HTTP client interface for XPath based
+        languages. The HTTP client interface is provided through a single
+        extension function which performs HTTP requests, and associated
+        error codes which define client error states.
+      </p>
+      <p>
+        It has been designed to be compatible via [[!XPATH20]] with
+        [[!XQUERY]], and [[!XSLT20]]. It should also be suitable
+        for any other language which hosts XPath 2.0, such as [[!XPROC]].
       </p>
     </section>
     <section id="sotd">
@@ -187,7 +192,7 @@
       <h2>Introduction</h2>
       <section>
 	<h3>Namespace conventions</h3>
-        <p>The module defined by this document does define one function in the namespace
+        <p>The module defined by this document defines one function in the namespace
           <code>http://expath.org/ns/http-client</code>. In this document, the
           <code>http</code> prefix, when used, is bound to this namespace URI.</p>
         <p>Error codes are defined in the namespace <code>http://expath.org/ns/error</code>. In this
@@ -198,18 +203,18 @@
         <p>Error conditions are identified by a code (a <code>QName</code>). When such an error
           condition is reached during the execution of the function, a dynamic error is thrown, with
           the corresponding error code (as if the standard XPath function
-          <code>error</code> had been called).</p>
-        <p>Error codes are defined through the spec. For too many reasons to enumerate here, the
-          HTTP protocol layer can raise an error. In this case, if the error condition is not
-          mentioned explicitly in the spec, the implementation must raise an error with an
-          appropriate message <a href="#dfn-errHC001">err:HC001</a>.</p>
+          <a data-cite="xpath-functions#func-error">fn:error</a> had been called).</p>
+        <p>There are many cases where the
+          HTTP protocol layer may raise an error. In each case, if the error condition is not
+          mentioned explicitly in the spec, the implementation MUST raise an error with the
+          error code <a>err:HC001</a>.</p>
       </section>
     </section>
 
     <section>
       <h2>The <dfn>http:send-request</dfn> function</h2>
-      <p>This module defines an XPath extension function that sends an HTTP request and return the
-        corresponding response. It supports HTTP multi-part messages. Here is the signature of this
+      <p>This module defines an XPath extension function that sends an HTTP request and returns the
+        corresponding response. It also supports HTTP multi-part messages. Here is the signature of this
         function:</p>
       <div class="proto">
         <table class="proto">
@@ -233,23 +238,23 @@
       <ul>
         <li><code>$request</code> contains the various parameters of the request, for instance the
           HTTP method to use or the HTTP headers. Among other things, it can also contain the other
-          param's values: the URI and the bodies. If they are not set as parameter to the function,
-          their value in $request, if any, is used instead. See the following section for the
-          detailed definition of the http:request element. If the parameter does not follow the
-          grammar defined in this spec, this is an error <a href="#dfn-errHC005">err:HC005</a>.</li>
-        <li><code>$href</code> is the HTTP or HTTPS URI to send the request to. It is an xs:anyURI,
-          but is declared as a string to be able to pass literal strings (without requiring to
-          explicitly cast it to an xs:anyURI).</li>
+          parameters' values: the URI and the body(s). If they are not set as parameters to the function,
+          their value in <code>$request</code>, if any, is used instead. See the <a href="#request-element" class="sectionRef"></a> for the
+          definition of the <a>http:request</a> element. If the parameter does not follow the
+          grammar defined in this spec, the error <a>err:HC005</a> MUST be raised.</li>
+        <li><code>$href</code> is the HTTP or HTTPS URI to send the request to. It is an <code>xs:anyURI</code>,
+          but is declared as an xs:string so that literal strings may be used; in other words, the parameter does not
+          need to be explicitly cast as <code>xs:anyURI</code>).</li>
         <li><code>$bodies</code> is the request body content, for HTTP methods that can contain a
-          body in the request (e.g. POST). This is an error if this param is not the empty sequence
+          body in the request (e.g. POST). It is an error if this parameter is not the empty sequence
           for methods that must be empty (e.g. DELETE). The details of the methods are defined in
-          their respective specs (e.g. [[!rfc2616]] or [[!rfc4918]]). In case of a multipart
+          their respective specifications (e.g. [[!rfc2616]] or [[!rfc4918]]). In case of a multipart
           request, it can be a sequence of several items, each one is the body of the corresponding
           body descriptor in
-          <code>$request</code>. See below for details.</li>
+          <code>$request</code>; see <a>http:multipart</a>.</li>
       </ul>
-      <p>Besides the 3-params signature above, there are 2 other signatures that are convenient
-        shortcuts (corresponding to the full version in which corresponding params have been set
+      <p>Besides the arity-three signature above, there are two other signatures that are convenient
+        shortcuts (corresponding to the full version in which corresponding parameters have been set
         to the empty sequence). They are:</p>
       <div class="proto">
         <code class="function">http:send-request</code>(<code class="arg">$request</code><code class="as"> as </code><code class="type">element(http:request)?</code>, <code class="arg">$href</code><code class="as"> as </code><code class="type">xs:string?</code>) as <code class="return-type">item()+</code>
@@ -261,19 +266,19 @@
 
     <section>
       <h2>Sending a request</h2>
-      <p>The functions defined in this module make one able to send a request to an HTTP server and
-        receive the corresponding response.  Here is how the request is represented by the
-        parameters to this function, and how they are used to generate the actual HTTP request to
-        send.</p>
+      <p>The functions defined in this module allow the transmission of a request to an HTTP server and
+        the reception of the corresponding response. The request is represented by the
+        parameters to the function, which define how to generate the actual HTTP request to
+        transmit.</p>
 
-      <section>
-        <h3>The request elements</h3>
-        <p>The <code>http:request</code> element represents all the needed information to send the
-          HTTP request.  So it is always possible to create such an element that will carry over all
-          the needed info for a particular request.  For some of those values though, you can use an
-          additional param instead.  For instance, some signatures define the
+      <section id="request-element">
+        <h3>The Request Element</h3>
+        <p>The <dfn><code>http:request</code></dfn> element represents all the information needed to send the
+          HTTP request.</p>
+        <p>Some of the values defined for the <a>http:request</a> element can instead be set through
+          a parameter to the function. For instance, some signatures define the
           parameter <code>$href</code>.  If the value of this parameter is not the empty sequence,
-          it will then be used instead of the value of the attribute <code>href</code> on
+          it will override the value of the attribute <code>href</code> on
           the <code>http:request</code> element.</p>
 
         <div class="proto">
@@ -294,43 +299,38 @@
         </div>
 
         <ul>
-          <li><code>method</code> is the HTTP verb to use, as GET, POST, etc.  It is case
-            insensitive</li>
-          <li><code>href</code> is the URI the request has to be sent to.  It can be overridden by
+          <li><code>method</code> is the <a data-cite="rfc1945#section-8">HTTP method</a>
+            to use, e.g.: <code>GET</code>, <code>HEAD</code>, <code>POST</code>, etc. It is case insensitive</li>
+          <li><code>href</code> is the URI that the request is made to. It can be overridden by
             the parameter <code>$href</code></li>
           <li><code>http-version</code> is the version of HTTP to use. It must be either the
             string <code>1.0</code> or <code>1.1</code>. Default is implementation-defined.  An
             implementation SHOULD support both and the default SHOULD be
             <code>1.1</code>. If the value specified is not supported by a specific implementation,
-            it should throw an appropriate error message <a href="#dfn-errHC007">err:HC007</a>.</li>
-          <li><code>status-only</code> control how the response will look like; if it is true, only
-            the status code and the headers are returned, the content is not (no http:body nor
-            http:multipart, nor the interpreted additional value in the returned sequence, see
-            hereafter).</li>
+            it MUST throw the error <a>err:HC007</a>.</li>
+          <li><code>status-only</code> controls how the response will be parsed; if it is true, only
+            the status code and the headers are returned, and the content is omitted (no <a>http:body</a>, nor
+            <a>http:multipart</a>, nor the interpreted additional value in the returned sequence).</li>
           <li><code>username</code>, <code>password</code>, <code>auth-method</code>
-            and <code>send-authorization</code> are used for authentication (see section
-            below).</li>
-          <li><code>override-media-type</code> is a MIME type.  It can be used only with
-            <code>http:request</code>, and will override the Content-Type header returned by the
-            server.</li>
-          <li><code>follow-redirect</code> control whether an HTTP redirect is automatically
-            followed or not.  If it is false, the HTTP redirect is returned as the response.  If it
-            is true (the default) the function tries to follow the redirect, by sending the same
+            and <code>send-authorization</code> are used for authentication (see <a href="#authentication" class="sectionRef"></a>).</li>
+          <li><code>override-media-type</code> is a Media Type ([[rfc6838]]).  It can be used only with
+            <a>http:request</a>, and will override the <code>Content-Type</code>
+            header in the HTTP Response returned by the server.</li>
+          <li><code>follow-redirect</code> controls whether an HTTP redirect is automatically
+            followed or not.  If it is <code>false</code>, the HTTP redirect is returned as the response.  If it
+            is <code>true</code> (the default) the function tries to follow the redirect, by sending the same
             request to the new address (including body, headers, and authentication credentials).
             Maximum one redirect is followed (there is no attempt to follow a redirect in response
             to following a first redirect).</li>
           <li><code>timeout</code> is the maximum number of seconds to wait for the server to
-            respond. If this time duration is reached, an error is thrown
-            <a href="#dfn-errHC006">err:HC006</a>.</li>
-          <li><code>http:header</code> represent an HTTP header, either in the
-            <code>http:request</code> or in the <code>http:response</code> elements, as defined
-            below.</li>
-          <li><code>http:multipart</code> represents a multi-part body, either in a request or a
-            response, as defined below.</li>
-          <li><code>http:body</code> represents the body, either of a request or a response, as
-            defined below.</li>
+            respond. If this time duration is exceeded, the error <a>err:HC006</a> MUST be raised.</li>
+          <li><a><code>http:header</code></a> represents an HTTP header, either in the
+            <a>http:request</a> or in the <a>http:response</a> elements.</li>
+          <li><a><code>http:multipart</code></a> represents a multi-part body, either in a request or a
+            response.</li>
+          <li><a><code>http:body</code></a> represents the body, either of a request or a response.</li>
         </ul>
-        <p>The <code>http:header</code> element represents an HTTP header, either in a request or in
+        <p>The <dfn><code>http:header</code></dfn> element represents an HTTP header, either in a request or
           a response:</p>
         <div class="proto">
           <pre>
@@ -339,8 +339,8 @@
    &lt;!-- Content: empty -->
 &lt;/http:header></pre>
           </div>
-        <p>The <code>http:body</code> element represents the body of either an HTTP request or of an
-          HTTP response (in multipart requests and responses, it represents the body of a single one
+        <p>The <dfn><code>http:body</code></dfn> element represents the body of either an HTTP request or an
+          HTTP response (in multipart requests and responses, it represents the body of a single
           part):</p>
         <div class="proto">
           <pre>
@@ -365,23 +365,22 @@
    &lt;!-- Content: any* -->
 &lt;/http:body></pre>
           </div>
-        <p>The <code>media-type</code> is the MIME media type of the body part. It is mandatory.  In
-          a request it is given by the user and is the default value of the Content-Type header if
-          it is not set explicitly. In a response, it is given by the implementation from the
-          Content-Type header returned by the server. The <code>src</code> attribute can be used in
+        <p>The <code>media-type</code> is the media type of the body part. It is mandatory. In
+          a request it is provided by the user and is the default value of the <code>Content-Type</code> header if
+          it is not set explicitly. In a response, it is provided by the implementation from the
+          <code>Content-Type</code> header returned by the server. The <code>src</code> attribute can be used in
           a request to set the body content as the content of the linked resource instead of using
-          the children of the <code>http:body</code> element. When this attribute is used, only
+          the children of the <a>http:body</a> element. When this attribute is used, only
           the <code>media-type</code> attribute must also be present, and there can be neither
-          content in the <code>http:body</code> element, nor any other attribute, or this is an
-          error <a href="#dfn-errHC004">err:HC004</a>.</p>
+          content in the <code>http:body</code> element, nor any other attribute, otherwise the
+          error <a>err:HC004</a> MUST be raised.</p>
         <p>All the attributes, except <code>src</code>, are used to set the corresponding
-          serialization parameter defined in [[!xslt-xquery-serialization]], as defined for the
-          XPath 3.0 function <code>fn:serialize()</code> [[!xpath-functions-30]]. Those attributes
-          can be given by the user on a request to control the way a part body is serialized. In the
+          serialization parameters defined in [[!xslt-xquery-serialization]]. Those attributes
+          can be provided by the user on a request to control the way a part body is serialized. In the
           response, the implementation can, but is not required, to provide some of them if it has
           the corresponding information (some of them do not make any sense in a response, therefore
-          they will never be on a response element, for instance <code>version</code>).</p>
-        <p>The <code>http:multipart</code> element represents an HTTP multi-part request or
+          they will never be supplied on the response element, for instance <code>version</code>).</p>
+        <p>The <dfn><code>http:multipart</code></dfn> element represents an HTTP <a data-cite="rfc1945#section-3.6.2">Multipart Type</a> request or
           response:</p>
         <div class="proto">
           <pre>
@@ -394,31 +393,31 @@
           and has to be a multipart media type (that is, its main type must be
           <code>multipart</code>). The <code>boundary</code> attribute is the boundary marker used
           to separate the several parts in the message (the value of the attribute is prefixed with
-          "<code>--</code>" to form the actual boundary marker in the request; on the other way,
+          "<code>--</code>" to form the actual boundary marker in the request; conversely,
           this prefix is removed from the boundary marker in the response to set the value of the
           attribute).</p>
       </section>
 
       <section>
-        <h3>Serializing the request content</h3>
-        <p>If the request can have content (one body or several body parts), it can be specified by
-          the <code>http:multipart</code> element, the <code>http:body</code> element, and/or the
+        <h3>Serializing the Request</h3>
+        <p>If the request entity body has content (one body or several body parts), it can be specified by
+          the <a>http:multipart</a> element, the <a>http:body</a> element, and/or the
           parameter <code>$bodies</code>. For each body, the content of the HTTP body is generated
-          as follow.</p>
-        <p>Except when its attribute <code>src</code> is present, a <code>http:request</code>
+          as follows.</p>
+        <p>Except when its attribute <code>src</code> is present, a <a>http:request</a>
           element can have several attributes representing serialization parameters, as defined in
           [[!xslt-xquery-serialization]]. This spec defines in addition the method
-          <code>'binary'</code>; in this case the body content must be either an xs:hexBinary or an
-          xs:base64Binary item, and no other serialization parameter can be set
+          <code>binary</code>; in this case the body content must be either an <code>xs:hexBinary</code> or an
+          <code>xs:base64Binary</code> item, and no other serialization parameter can be set
           besides <code>media-type</code>.</p>
         <p>The default value of the serialization method depends on the <code>media-type</code>: it
-          is <code>'xml'</code> if it is an XML media type, <code>'html'</code> if it is an HTML
-          media type, <code>'xhtml'</code> if it is <code>application/xhtml+xml</code>,
-          <code>'text'</code> if it is a textual media type, and <code>'binary'</code> for any other
+          is <code>xml</code> if it is an XML media type, <code>html</code> if it is an HTML
+          media type, <code>xhtml</code> if it is <code>application/xhtml+xml</code>,
+          <code>text</code> if it is a textual media type, and <code>binary</code> for any other
           case.</p>
-        <p>When a body element has an empty content (i.e. it has no child node at all) its content
-          is given by the parameter <code>$bodies</code>. In a single part request, this param must
-          have at most one item. If the body is empty, the param cannot be the empty sequence. In a
+        <p>When a body element has no content (i.e. no child nodes) its content
+          is given by the parameter <code>$bodies</code>. In a single part request, this parameter must
+          have at most one item. If the body is empty, the parameter cannot be the empty sequence. In a
           multipart request, <code>$bodies</code> must have as many items as there are empty body
           elements. If there are three empty body elements, the content of the first of them
           is <code>$bodies[1]</code>, and so on. The number of empty body elements must be equal to
@@ -429,30 +428,31 @@
         <h3>Authentication</h3>
         <p>HTTP authentication when sending a request is controlled by the attributes 
           <code>username</code>, <code>password</code>, <code>auth-method</code> and
-          <code>send-authorization</code> on the element <code>http:request</code>.
+          <code>send-authorization</code> on the <a>http:request</a> element.
           If <code>username</code> has a value, <code>password</code> and
           <code>auth-method</code> must have a value too.  And if any one of the three other
           attributes have been set, <code>username</code> must be set too.</p>
-        <p>The attribute <code>auth-method</code> can be either <code>"Basic"</code> or
-          <code>"Digest"</code>, but other values can also be used, in an implementation-defined
-          way.  The handling of those attributes must be done in conformance to [[!rfc2617]].
-          If <code>send-authorization</code> is true (default value is false) and the authentication
+        <p>The attribute <code>auth-method</code> can be either <code>Basic</code> or
+          <code>Digest</code>, but other values can also be used, in an implementation-defined
+          way. The handling of those attributes must be done in conformance with [[!rfc2617]].
+          If <code>send-authorization</code> is <code>true</code> (default value is <code>false</code>) and the authentication
           method supports generating the header <code>Authorization</code> without challenge, the
-          request contains this header.  The default value is to send a non-authenticated request,
-          and if the response is an authentication challenge, then only send the credentials in a
-          second message.</p>
+          request contains this header. The default value is to send a non-authenticated request,
+          and if the response is an authentication challenge, only then send the credentials in a
+          second request.</p>
       </section>
     </section>
 
     <section>
-      <h2>Dealing with the response</h2>
+      <h2>Handling the Response</h2>
       <p>After having sent the request to the HTTP server, the function waits for the response.
-        It analyses it and returns a sequence representing this response.  This sequence has
-        an <code>http:response</code> element as first item, which is followed be an additional
+        The HTTP client parses the raw response and the function returns a representation of the
+        response as a sequence. The sequence has
+        an <a>http:response</a> element as the first item, which is followed by an additional
         item for each body or body part in the response.</p>
 
       <section>
-        <h3>The result element</h3>
+        <h3>The Response Element</h3>
         <div class="proto">
           <pre>
 &lt;http:response status = integer
@@ -460,86 +460,84 @@
    &lt;!-- Content: (http:header*, (http:body|http:multipart)?) -->
 &lt;/http:response></pre>
         </div>
-        <p>This is the first item returned by the function defined in this module.
-          The <code>status</code> attribute is the HTTP status code returned by the server,
-          and <code>message</code> is the message coming with the status on the status line.
+        <p>The <dfn>http:response</dfn> element is the first item in the sequence returned by the function.
+          The <code>status</code> attribute is the HTTP <a data-cite="rfc1945#section-6.1.1">Status Code</a> returned by the server,
+          and <code>message</code> is the Reason Phrase coming with the <a data-cite="rfc1945#section-6.1">Status-Line</a>.
           The <code>http:header</code> elements are as defined for the request, but represent
-          instead the response headers.  The <code>http:body</code>
-          and <code>http:multipart</code> elements are also like in the request, but
+          instead the response headers. The <a>http:body</a>
+          and <a>http:multipart</a> elements are also like in the request, but
           <code>http:body</code> elements must be empty.</p>
       </section>
 
       <section>
-        <h3>Representing the result content</h3>
-        <p>Instead of being inserted within the <code>http:response</code> element, the content of
-          each body is returned as a single item in the return sequence.  Each item is in the same
-          order (after the <code>http:response</code> element) than the <code>http:body</code>
-          elements.  For each body, the way this item is built from the HTTP response is as
+        <h3>The Response Entity Body</h3>
+        <p>Instead of being inserted within the <a>http:response</a> element, the content of
+          each body is returned as a single item in the returned sequence. Each item is in the same
+          order (after the <a>http:response</a> element) as the <a>http:body</a>
+          elements. For each body, the way this item is built from the HTTP response is as
           follow.</p>
         <p>If the <code>status-only</code> attribute has the value <code>true</code> (default
           is <code>false</code>), the returned sequence will only contain the
-          <code>http:response</code> element (with the headers, but also the empty
-          <code>http:body</code> or <code>http:multipart</code> elements, as if
-          <code>status-only</code> was false), and the following items, representing the bodies
+          <a>http:response</a> element (with the headers, but also the empty
+          <a>http:body</a> or <a>http:multipart</a> elements, as if
+          <code>status-only</code> was <code>false</code>), and the following items, representing the bodies
           content are not generated from the HTTP response.</p>
-        <p>For each body that has to be interpreted, the following rules apply in order to build the
-          corresponding item.  If the body media type is a text media type, the item is a string,
-          containing the body content.  If the media type is an XML media type, the content is
-          parsed and the item is the resulting document node.  If the media type is an HTML type,
+        <p>For each body that has to be parsed, the following rules apply in order to build the
+          corresponding XDM item. If the body media type is a text media type, the item is an <code>xs:string</code>,
+          containing the body content. If the media type is an XML media type, the content is
+          parsed and the item is the resulting XDM <code>document-node</code>. If the media type is an HTML type,
           the content is <emph>tidied up</emph> and parsed (this process is
-          implementation-dependant) and the item is the resulting document node.  If this is a
-          binary media type, the content is returned as a base64Binary item.  From the previous
-          rules, a result item can then be either a document node (from XML or HTML), a string or a
-          base64Binary.</p>
+          both implementation-dependent and implementation-defined) and the item is the resulting XDM <code>document-node</code>.  If this is a
+          binary media type, the content is returned as an <code>xs:base64Binary</code> item.  From the previous
+          rules, a result item can then be either a <code>document-node</code> (from XML or HTML), an <code>xs:string</code>, or a
+          <code>xs:base64Binary</code>.</p>
         <p>When the type of a part is either XML or HTML, its body has to be parsed into a document
-          node. If there is any error when parsing the content, an error is raised with an
-          appropriate message <a href="#dfn-errHC002">err:HC002</a>.</p>
+          node. If an error occurs whilst parsing the content, the error <a>err:HC002</a> MUST be raised.</p>
         <p>If the attribute <code>override-media-type</code> is set on the request, its value is
-          used instead of the Content-Type returned by the HTTP server. If the Content-Type of the
-          response is a multipart type, the value of <code>override-media-type</code> can only be a
+          used instead of the <code>Content-Type</code> header returned by the HTTP server. If the <code>Content-Type</code> header of the
+          response indicates a multipart type, the value of <code>override-media-type</code> can only be a
           multipart type, or <code>application/octet-stream</code> (to get the raw entity as a
-          binary item). If it is not, this is an error <a href="#dfn-errHC003">err:HC003</a>.</p>
+          binary item). If it is not, the error <a>err:HC003</a> MUST be raised.</p>
       </section>
     </section>
 
     <section>
-      <h2>Content types handling</h2>
-      <p>In both requests and responses, MIME type strings are used to choose the way the entity
-        content has to be respectively serialized or parsed.  Four different kinds of type are
-        defined here, which are used in the above text about sending request and receiving response.
-        The intent is to provide the spirit of the entity content handling regarding its content
-        type, but an implementation is encouraged to deviate from those rules if it is obvious that
-        a particular type should be treated in a specific way (normally, that would be the case only
-        to treat a binary type as another type).</p>
+      <h2>Processing Media Types</h2>
+      <p>In both requests and responses, Media Type strings are used to choose the way the entity
+        content has to be serialized or parsed.</p>
+      <p>We define four different classes of Media Type, which are used for sending requests and receiving responses.
+        The intent is to provide guidance as to handling the entity content with respect to its content
+        type, but an implementation is permitted to deviate from those rules if it is obvious that
+        a particular type should be treated in a specific way, typically this can be useful for binary types such as [[EXI]].</p>
       <ul>
-        <li>An XML media type has a MIME type of <code>text/xml</code>,
+        <li>For XML the following media types are appropriate: <code>text/xml</code>,
           <code>application/xml</code>, <code>text/xml-external-parsed-entity</code>,
           or <code>application/xml-external-parsed-entity</code>, as defined in [[!rfc3023]] (except
-          that <code>application/xml-dtd</code> is considered a text media type).  MIME types ending
-          by <code>+xml</code> are also XML media types.</li>
-        <li>An HTML media type has a MIME type of <code>text/html</code>.</li>
-        <li>Text media types are the remaining types beginning with <code>text/</code>.</li>
-        <li>Binary types are all the other types.  An implementation can treat some of those binary
+          that <code>application/xml-dtd</code> is considered a text media type). Media types ending
+          with <code>+xml</code> are also considered XML types.</li>
+        <li>For HTML the media type <code>text/html</code> is suggested.</li>
+        <li>For Text, a media type beginning with <code>text/</code> is suggested.</li>
+        <li>All other media types are treated as binary. An implementation MAY treat some of those binary
           types as either an XML, HTML or text media type if it is more appropriate (this is
           implementation-defined).</li>
       </ul>
     </section>
 
     <section class="appendix">
-      <h2>Summary of Error Conditions</h2>
+      <h2>Error Codes</h2>
       <dl>
         <dt><dfn id="dfn-errHC001">err:HC001</dfn></dt>
         <dd>An HTTP error occurred.</dd>
         <dt><dfn id="dfn-errHC002">err:HC002</dfn></dt>
         <dd>Error parsing the entity content as XML or HTML.</dd>
         <dt><dfn id="dfn-errHC003">err:HC003</dfn></dt>
-        <dd>With a multipart response, the override-media-type must be either a multipart media type
-          or application/octet-stream.</dd>
+        <dd>A multipart response was received, but the <code>override-media-type</code> was not a multipart media type
+          or <code>application/octet-stream</code>.</dd>
         <dt><dfn id="dfn-errHC004">err:HC004</dfn></dt>
-        <dd>The src attribute on the body element is mutually exclusive with all other attribute
-          (except the media-type).</dd>
+        <dd>The <code>src</code> attribute on the body element is mutually exclusive with all other attribute
+          (except the <code>media-type</code>).</dd>
         <dt><dfn id="dfn-errHC005">err:HC005</dfn></dt>
-        <dd>The request element is not valid.</dd>
+        <dd>The <a>http:request</a> element is invalid.</dd>
         <dt><dfn id="dfn-errHC006">err:HC006</dfn></dt>
         <dd>A timeout occurred waiting for the response.</dd>
         <dt><dfn id="dfn-errHC007">err:HC007</dfn></dt>


### PR DESCRIPTION
I have gone through the HTTP Client 1.0 spec from top to bottom.

1. I have tried to make minor improvements to the English language to make the intention clearer.
2. I have simplified some of the html code, reSpec does a lot of automation for you, that you don't need to duplicate e.g. you don't need to specify the `id` on an `<a>` when linking to a definition.
3. I have improved the internal linking between terms and their definitions.
4. I have added further external links and references where appropriate.

I think the spec still has a rather conversational style and uses too much wordy text to define things, where bullet points, or a more succinct style could be used.

I have not made any major sweeping changes to the text, as unfortunately I don't have the time to spend on that.

There are some technical issues which could be improved. However I don't think it is worth the effort, as it has been 8 years since the last draft of the spec; It seems unlikely that anyone would implement them (especially in light of the HTTP 2.0 module draft being available).