### PR TITLE
Switch the HTTP Client 2.0 spec to a CG spec.

### DIFF
--- a/specs/http-client-2/index.html
+++ b/specs/http-client-2/index.html
@@ -6,11 +6,17 @@
     <script src='https://www.w3.org/Tools/respec/respec-w3c-common' class='remove'></script>
     <script class='remove'>
       var respecConfig = {
-          // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
-          specStatus: "ED",
+          // the CG
+          wg: "EXPath Community Group",
+          wgURI: "https://www.w3.org/community/expath/",
+          repoURL: "https://github.com/expath/expath-cg/",
+          wgPublicList: "public-expath",
+
+          // specification status (e.g. WD, LCWD, NOTE, etc.). CG-DRAFT and CG-FINAL for CG reports
+          specStatus: "CG-DRAFT",
 
           // the specification's short name, as in http://www.w3.org/TR/short-name/
-          shortName: "http-client-2",
+          shortName: "expath-http-client-2",
 
           // if your specification has a subtitle that goes below the main
           // formal title, define it here
@@ -32,10 +38,6 @@
           // edDraftURI: "http://dev.w3.org/2009/dap/ReSpec.js/documentation.html",
           edDraftURI: "https://expath.github.io/expath-cg/specs/http-client-2/",
 
-          wgURI: "https://www.w3.org/community/expath/",
-          wgPublicList: "public-expath",
-          repoURL: "https://github.com/expath/expath-cg/",
-
           // if this is a LCWD, uncomment and set the end of its review period
           // lcEnd: "2009-08-05",
 
@@ -53,15 +55,6 @@
           // only "name" is required. Same format as editors.
           //authors: [
           //],
-
-          // name of the WG
-          wg: "EXPath Community Group",
-
-          // URI of the public WG page
-          wgURI: "https://www.w3.org/community/expath/",
-
-          // name (without the @w3c.org) of the public mailing to which comments are due
-          //wgPublicList: "exquery-restxq",
 
           // URI of the patent status for this WG, for Rec-track documents
           // !!!! IMPORTANT !!!!
@@ -92,6 +85,22 @@
               ]
             }
           },
+
+          otherLinks: [
+            {
+	      key: 'Participate',
+	      data: [
+                {
+	          value: 'GitHub expath/expath-cg',
+	          href: 'https://github.com/expath/expath-cg/'
+	        },
+                {
+	          value: 'Report an issue',
+	          href: 'https://github.com/expath/expath-cg/issues/'
+	        }
+              ]
+	    }
+          ]
       };
     </script>
     <style>


### PR DESCRIPTION
Just changes the template used so that it is a Community Group spec. Also tweaks a couple of things to bring them inline with the updated HTTP Client 1.0 ReSpec metadata.